### PR TITLE
Debugged Items

### DIFF
--- a/app/components/Author/index.js
+++ b/app/components/Author/index.js
@@ -74,7 +74,7 @@ export const AuthorDesc = styled.div`
   flex-grow: 1;
   text-align: ${p=>p.theme.isArabic?'right':'left'} !important;
   display: inline-block;
-  padding-left: 28px;
+  padding-${p=>p.theme.isArabic?'right':'left'}: 28px;
 
   p {
     margin: 0;

--- a/app/containers/ToolKeyItems/index.js
+++ b/app/containers/ToolKeyItems/index.js
@@ -80,6 +80,7 @@ class ToolKeyItems extends React.PureComponent { // eslint-disable-line react/pr
     const showTheories = this.props.showIfUntranslated('key-theories');
     const showMethodologies = this.props.showIfUntranslated('key-methodologies');
 
+    
     return (
       <LanguageThemeProvider>
         <section>

--- a/app/containers/ToolPage/MainStage/Untranslated.js
+++ b/app/containers/ToolPage/MainStage/Untranslated.js
@@ -21,7 +21,7 @@ import staticText from '../staticText';
 function Untranslated(props) { // eslint-disable-line react/prefer-stateless-function
 
   const { buildMessage } = props.translatable;
-  const origLink = `/${props.lang}/tool/${props.slug}`;
+  const origLink = `/en/tool/${props.slug}`;
   const message = buildMessage(staticText.translationNeeded, {
     link: origLink,
     form: buildMessage(staticText.needsTranslationForm)

--- a/app/containers/ToolPage/MainStage/Untranslated.js
+++ b/app/containers/ToolPage/MainStage/Untranslated.js
@@ -14,7 +14,7 @@ import { injectStaticText } from 'containers/TranslatableStaticText';
 import { ContentContainer } from 'components/ToolPage/Main'
 import ContentBlock from 'components/ContentBlock';
 import LanguageThemeProvider from 'components/LanguageThemeProvider';
-import {MODULE_TYPE_UNTRANSLATED} from 'components/CommonComponents/constants';
+import { MODULE_TYPE_UNTRANSLATED } from 'components/CommonComponents/constants';
 
 import staticText from '../staticText';
 
@@ -27,7 +27,9 @@ function Untranslated(props) { // eslint-disable-line react/prefer-stateless-fun
     form: buildMessage(staticText.needsTranslationForm)
   })
 
-  if (props['module-type-effective'] !== MODULE_TYPE_UNTRANSLATED) return null;
+  if (props.showIfUntranslated('full-write-up')) {
+    return null;
+  }
 
   return (
     <ContentContainer>

--- a/app/containers/ToolPage/index.js
+++ b/app/containers/ToolPage/index.js
@@ -34,7 +34,7 @@ import Sidebar from './Sidebar';
 import HomePage from 'containers/HomePage';
 
 import {BR_IMAGE_PREFIX} from 'containers/Tools/constants';
-import { MODULE_TYPE_UNTRANSLATED } from 'components/CommonComponents/constants';
+import { MODULE_TYPE_UNTRANSLATED, MODULE_TYPE_GALLERY } from 'components/CommonComponents/constants';
 
 
 
@@ -59,8 +59,12 @@ export class ToolPage extends React.PureComponent { // eslint-disable-line react
   showIfUntranslated(attr) {
     const tool = this.props.toolData.getIn(['tool']);
 
-    if ( tool['module-type-effective'] !== MODULE_TYPE_UNTRANSLATED ) {
-       return true
+    if ( tool['module-type-effective'] === MODULE_TYPE_GALLERY
+          && tool['lang-missing'].includes(attr)) {
+      return this.state.showUntranslated;
+
+    } else if ( tool['module-type-effective'] !== MODULE_TYPE_UNTRANSLATED ) {
+       return true;
     }
 
     return this.state.showUntranslated && tool['lang-missing'].includes(attr);
@@ -70,8 +74,6 @@ export class ToolPage extends React.PureComponent { // eslint-disable-line react
     const tool = this.props.toolData.getIn(['tool']);
     const lang = this.props.intl.locale;
     if (!tool.document_id) return null;
-
-    console.log(tool['module-type-effective']);
 
     if (tool['module-type-effective'] === 'snapshot') {
       return (<HomePage popup={tool} />)


### PR DESCRIPTION

- [x] Snapshot popup – Remove the pattern at the background
- [x] Search “Expressive and instrumental” open as a pop-up
- [x] If a user sends a unique URL for a popup -> homepage, popup there
https://beautifulrising.org/tool/forum-theatre -> Street theatre

- [x] Open as a pop up in the homepage
- [x] Full to Gallery should be respected in render
    - [x] This should show the “translation needed text”
    - [x] Eliminate everything that shows up in English
    - [x] “Battle of the Camel” 
    - [x] Should always default to English… always
		1. Battle of the Camel
		2. Post Colonialism 
		3. Feminism
- [x] Fix this:
￼<img width="681" alt="screen shot 2017-11-29 at 4 15 15 pm" src="https://user-images.githubusercontent.com/399692/33517726-37e10aec-d757-11e7-9bd3-f1ef9faffd5b.png">
￼
